### PR TITLE
Fix parameter ordering, add token splitter, add _en versions for random sources, add generic scoreboard

### DIFF
--- a/simlib/README.md
+++ b/simlib/README.md
@@ -6,7 +6,7 @@ Components in this folder are not synthesizable and should not be used in a fina
 
 ## Contents
 
-This library contains components for various purposes. A brief list can be found here.
+This library contains components for various purposes. A brief list can be found here. All components under [sources], [sinks], and [random generators] have enable versions, wich additionally expose a flag to control token flow.
 
 ### Sources
 
@@ -14,7 +14,7 @@ This library contains components for various purposes. A brief list can be found
 * `source_static_multi`: Simple multi-ended source that will repeatedly emit a static value token
 * `source_sequence`: Emits a static sequence of token values on a single output channel, can loop through the values
 * `source_sequence_multi`: Emits a static sequence of token values on a configurable number of output channels, can loop through the values
-* `source_file`: Emits a list of tokens given through an input file on a single output channel. The input file format supports comments, and is base 10 by default. Base 2 (0b), 8 (0o), and 16 (0x) are also supported. The input file must not have any trailing newlines.
+* `source_file`: Emits a list of tokens given through an input file on a single output channel. The input file format supports comments, and is base 10 by default. Base 2 (0b), 8 (0o), and 16 (0x) are also supported.
 * `source_file_multi`: Same as `source_file`, but with a configurable number of output channels.
 
 ### Sinks
@@ -54,8 +54,7 @@ This library contains components for various purposes. A brief list can be found
 ## Roadmap
 
 * Add tests for random sources
-* Add splitter to utility
-* Support trailing newline in file sources
+* Support trailing comments in file sources
 * Token counters; both to count to a parameter given number of tokens and raise a flag as well as count equal number of tokens on two different busses
 * Nondeterministic scoreboard for designs where the token order of design and model might differ but the token number is identical
 * Support for constrained random testing using new sources with C++ backend

--- a/simlib/README.md
+++ b/simlib/README.md
@@ -24,6 +24,7 @@ This library contains components for various purposes. A brief list can be found
 
 ### Scoreboards
 
+* `generic`: If your checks are more intricate than any of the pre-made scoreboards, this should be used for standardized logging and output parsing
 * `lockstep`: Used when one or more inputs and outputs are expected to see the same number of tokens in the same order for model and DUT
 * `deterministic`: Used when one or more output channels see the same number of tokens in the same order for model and DUT
 * `input_logger`: Used to log the input tokens for one or more input channels (identical to sink; same message format and verbosity parameters as scoreboards)
@@ -33,6 +34,7 @@ This library contains components for various purposes. A brief list can be found
 * `logger`: Zero-slack logger which reports tokens passing through the channel
 * `logger_file`: Zero-slack logger which prints tokens passing through the channel to a file (with configurable level of verbosity)
 * `buffer`: Infinite capacity buffer. Used to eliminate timing impact and channel blocking of simulation harness on the DUT
+* `splitter`: Copy tokens from one input channel to multiple
 
 ### File interaction
 

--- a/simlib/act/rand.act
+++ b/simlib/act/rand.act
@@ -236,6 +236,25 @@ defproc source_range_multi_en(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
     }
 }
 
+/**
+ * Cell which pulls constantly high
+ * Used to create a non-en version for sources
+ * and sinks
+ */
+defproc l_sethi (bool out)
+{
+    bool x;
+    
+    spec {
+        rand_init (x)
+    }
+    
+    prs {
+        [keeper=2;after=0] ~x -> out+
+        [keeper=2;after=0] x -> x-
+    }
+}
+
 /* source_simple_en with enable set to 1 */
 export defproc source_simple <: source_simple_en ()
 {

--- a/simlib/act/rand.act
+++ b/simlib/act/rand.act
@@ -255,28 +255,28 @@ defproc l_sethi (bool out)
     }
 }
 
-/* source_simple_en with enable set to 1 */
+/** source_simple_en with enable set to 1 */
 export defproc source_simple <: source_simple_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_simple_multi_en with enable set to 1 */
+/** source_simple_multi_en with enable set to 1 */
 export defproc source_simple_multi <: source_simple_multi_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_range_en with enable set to 1 */
+/** source_range_en with enable set to 1 */
 export defproc source_range <: source_range_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_range_multi_en with enable set to 1 */
+/** source_range_multi_en with enable set to 1 */
 export defproc source_range_multi <: source_range_multi_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
 }

--- a/simlib/act/rand.act
+++ b/simlib/act/rand.act
@@ -48,7 +48,7 @@ export function seed(int<32> prg_id; int<32> seed) : bool;
  *
  */
 export template<pint D_WIDTH, SOURCE_ID; pbool LOG>
-defproc source_simple(chan!(int<D_WIDTH>) O; bool enable)
+defproc source_simple_en(chan!(int<D_WIDTH>) O; bool enable)
 {
     int prg_id;
     int<D_WIDTH> buf;
@@ -98,7 +98,7 @@ defproc source_simple(chan!(int<D_WIDTH>) O; bool enable)
  *
  */
 export template<pint D_WIDTH, OUT_CHANNELS, SOURCE_ID; pbool LOG>
-defproc source_simple_multi(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
+defproc source_simple_multi_en(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
 {
     int prg_id;
     int<D_WIDTH> buf;
@@ -152,7 +152,7 @@ defproc source_simple_multi(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
  *
  */
 export template<pint D_WIDTH, MIN_VAL, MAX_VAL, SOURCE_ID; pbool LOG>
-defproc source_range(chan!(int<D_WIDTH>) O; bool enable)
+defproc source_range_en(chan!(int<D_WIDTH>) O; bool enable)
 {
     int prg_id;
     int<D_WIDTH> buf;
@@ -206,7 +206,7 @@ defproc source_range(chan!(int<D_WIDTH>) O; bool enable)
  *
  */
 export template<pint D_WIDTH, OUT_CHANNELS, MIN_VAL, MAX_VAL, SOURCE_ID; pbool LOG>
-defproc source_range_multi(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
+defproc source_range_multi_en(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
 {
     int prg_id;
     int<D_WIDTH> buf;
@@ -234,6 +234,30 @@ defproc source_range_multi(chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
             )
         ]
     }
+}
+
+/* source_simple_en with enable set to 1 */
+export defproc source_simple <: source_simple_en ()
+{
+  l_sethi lx(enable);
+}
+
+/* source_simple_multi_en with enable set to 1 */
+export defproc source_simple_multi <: source_simple_multi_en ()
+{
+  l_sethi lx(enable);
+}
+
+/* source_range_en with enable set to 1 */
+export defproc source_range <: source_range_en ()
+{
+  l_sethi lx(enable);
+}
+
+/* source_range_multi_en with enable set to 1 */
+export defproc source_range_multi <: source_range_multi_en ()
+{
+  l_sethi lx(enable);
 }
 
 }

--- a/simlib/act/scoreboards.act
+++ b/simlib/act/scoreboards.act
@@ -29,27 +29,44 @@ export function eof (int<32> reader_id) : bool;
 export function closer (int<32> reader_id) : bool;
 }
 
-export
-template<pint D_WIDTH; pint F_ID; pbool LOOP>
+/**
+ * Deprecated check sink from old simulation library
+ *
+ * This should not be used in new designs and will be removed
+ * in next version!
+ *
+ */
+export template<pint D_WIDTH; pint F_ID; pbool LOOP>
 defproc check_sink (chan?(int<D_WIDTH>) I)
 {
-  int<D_WIDTH> x, y;
-  int reader_id;
-  bool dummy;
-  chp {
-    *[  reader_id := file_private::openr (F_ID);
-      *[ I?x;
-           y := file_private::read(reader_id);
-         [ x = y -> skip
-         [] else -> log ("ASSERTION failed, value mismatch; expected: ", y, "%x (0x", y, "); got: ", x, "%x (0x", x, ")")
-         ]
-	  <- ~file_private::eof(reader_id)
-       ];
-        dummy := file_private::closer(reader_id)
-       <- LOOP
-    ];
-    log ("Sink file #", F_ID, " ends.")
-  }
+    int<D_WIDTH> x, y;
+    int reader_id;
+    bool dummy;
+
+    chp {
+        *[
+            // open the known good output file for reading
+            reader_id := file_private::openr (F_ID);
+
+            *[
+                // receive the input value
+                I?x;
+                y := file_private::read(reader_id);
+
+                // compare the values
+                [ x = y -> 
+                    skip
+                [] else -> 
+                    log ("ASSERTION failed, value mismatch; expected: ", y, "%x (0x", y, "); got: ", x, "%x (0x", x, ")")
+                ]
+
+	        <- ~file_private::eof(reader_id) ];
+
+            dummy := file_private::closer(reader_id)
+
+        <- LOOP ];
+        log ("Sink file #", F_ID, " ends.")
+    }
 }
 
 export namespace scoreboard {

--- a/simlib/act/scoreboards.act
+++ b/simlib/act/scoreboards.act
@@ -55,6 +55,70 @@ defproc check_sink (chan?(int<D_WIDTH>) I)
 export namespace scoreboard {
 
 /*
+ * Generic scoreboard
+ *
+ * Use this if your checks are more intricate and you only
+ * wish to use standardized logging
+ *
+ * Features:
+ * - Output token logging
+ *
+ * Assumes:
+ * - Valid channel receives true token if test succeeded
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels coming from the model / design
+ * - SB_ID: ID of the scoreboard (used in log output)
+ * - VERBOSE_TESTING: If false, only failed tests are logged
+ *
+ */
+export template <pint D_WIDTH, OUT_CHANNELS, SB_ID; pbool VERBOSE_TESTING>
+defproc generic (chan?(int<D_WIDTH>) OUT_M[OUT_CHANNELS], OUT_D[OUT_CHANNELS]; chan?(bool) SUCCESS)
+{
+    int<D_WIDTH> output_m[OUT_CHANNELS], output_d[OUT_CHANNELS];
+    bool success;
+    int num;
+
+    chp {
+        
+        num := 0;
+
+        *[
+            // receive the data
+            SUCCESS?success,
+            (, i : OUT_CHANNELS : OUT_M[i]?output_m[i]),
+            (, j : OUT_CHANNELS : OUT_D[j]?output_d[j]);
+
+            // print the output
+            [ not_failed -> (
+                
+                // only print successful tests if verbose testing is enabled
+                [ VERBOSE_TESTING -> (
+                    log_st ("");
+                    log_p ("Scoreboard ", SB_ID, ": TEST SUCCESS (", num, "); outputs {");
+                    (; i : OUT_CHANNELS : log_p (i, ": ", output_d[i], "%x (0x", output_d[i], "); "));
+                    log_p ("}");
+                    log_nl ("")
+                ) 
+                []  else -> (
+                    skip
+                )]
+            )
+            []  else -> (
+                log_st ("");
+                log_p ("Scoreboard ", SB_ID, ": TEST FAILED (", num, "); outputs {");
+                (; i : OUT_CHANNELS : log_p (i, ": expected ", output_m[i], "%x (0x", output_m[i], "), got ", output_d[i], "%x (0x", output_d[i], "); "));
+                log_p ("}");
+                log_nl ("")
+            )];
+            num := num + 1
+        ]
+
+    }
+}
+
+/*
  * Lockstep scoreboard
  *
  * Use this for a simple linear pipeline

--- a/simlib/act/scoreboards.act
+++ b/simlib/act/scoreboards.act
@@ -91,7 +91,7 @@ defproc generic (chan?(int<D_WIDTH>) OUT_M[OUT_CHANNELS], OUT_D[OUT_CHANNELS]; c
             (, j : OUT_CHANNELS : OUT_D[j]?output_d[j]);
 
             // print the output
-            [ not_failed -> (
+            [ success -> (
                 
                 // only print successful tests if verbose testing is enabled
                 [ VERBOSE_TESTING -> (

--- a/simlib/act/sinks.act
+++ b/simlib/act/sinks.act
@@ -124,16 +124,16 @@ defproc sink_file_en (chan?(int<D_WIDTH>) I; bool enable)
 }
 
 
-/* sink_en, with enable set to 1 */
+/** sink_en, with enable set to 1 */
 export defproc sink <: sink_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* sink_file_en with enable set to 1 */
+/** sink_file_en with enable set to 1 */
   export defproc sink_file <: sink_file_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
   
 }

--- a/simlib/act/sinks.act
+++ b/simlib/act/sinks.act
@@ -83,13 +83,13 @@ export function write_sink (int<32> writer_id; int<8> verbosity; int<32> sink_id
  *
  * Parameters:
  * - D_WIDTH: Data output bus width
- * - SINK_ID: ID of the sink (used in log output)
- * - F_ID: ID of the file to save into
  * - VERBOSITY: Verbosity with which to print to the file; 0: not verbose, 2: very verbose
+ * - F_ID: ID of the file to save into
+ * - SINK_ID: ID of the sink (used in log output)
  * - LOG: Logger enable parameter
  *
  */
-export template<pint D_WIDTH, SINK_ID, VERBOSITY, F_ID; pbool LOG>
+export template<pint D_WIDTH, VERBOSITY, F_ID, SINK_ID; pbool LOG>
 defproc sink_file_en (chan?(int<D_WIDTH>) I; bool enable)
 {
     int<D_WIDTH> buf;

--- a/simlib/act/sources.act
+++ b/simlib/act/sources.act
@@ -369,40 +369,40 @@ defproc source_file_multi_en (chan!(int<D_WIDTH>) O[OUT_CHANNELS]; bool enable)
 }
 
 
-/* source_static_en with enable set to 1 */
+/** source_static_en with enable set to 1 */
 export defproc source_static <: source_static_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_static_multi_en with enable set to 1 */
+/** source_static_multi_en with enable set to 1 */
 export defproc source_static_multi <: source_static_multi_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_sequence_en with enable set to 1 */
+/** source_sequence_en with enable set to 1 */
 export defproc source_sequence <: source_sequence_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_sequence_multi with enable set to 1 */
+/** source_sequence_multi with enable set to 1 */
 export defproc source_sequence_multi <: source_sequence_multi_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_file_en with enable set to 1 */
+/** source_file_en with enable set to 1 */
 export defproc source_file <: source_file_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
-/* source_file_multi_en with enable set to 1 */
+/** source_file_multi_en with enable set to 1 */
 export defproc source_file_multi <: source_file_multi_en ()
 {
-  l_sethi lx(enable);
+    l_sethi lx(enable);
 }
 
 }

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -92,13 +92,13 @@ export function write_log (int<32> writer_id; int<8> verbosity; int<32> log_id, 
  * Parameters:
  * - D_WIDTH: Data output bus width
  * - IN_CHANNELS: Number of channels
- * - LOG_ID: ID of the logger (currently unused)
  * - F_ID: ID of the file to save into
+ * - LOG_ID: ID of the logger (currently unused)
  * - VERBOSITY: Verbosity with which to print to the file; 0: not verbose, 2: very verbose
  * - LOG: Logger enable parameter
  *
  */
-export template<pint D_WIDTH, IN_CHANNELS, LOG_ID, F_ID, VERBOSITY; pbool LOG>
+export template<pint D_WIDTH, IN_CHANNELS, F_ID, LOG_ID, VERBOSITY; pbool LOG>
 defproc logger_file (chan?(int<D_WIDTH>) I[IN_CHANNELS]; chan!(int<D_WIDTH>) O[IN_CHANNELS])
 {
     int<D_WIDTH> buf[IN_CHANNELS];

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -88,13 +88,13 @@ export function write_log (int<32> writer_id; int<8> verbosity; int<32> log_id, 
  * Parameters:
  * - D_WIDTH: Data output bus width
  * - IN_CHANNELS: Number of channels
+ * - VERBOSITY: Verbosity with which to print to the file; 0: not verbose, 2: very verbose
  * - F_ID: ID of the file to save into
  * - LOG_ID: ID of the logger (used in log output)
- * - VERBOSITY: Verbosity with which to print to the file; 0: not verbose, 2: very verbose
  * - LOG: Logger enable parameter
  *
  */
-export template<pint D_WIDTH, IN_CHANNELS, F_ID, LOG_ID, VERBOSITY; pbool LOG>
+export template<pint D_WIDTH, IN_CHANNELS, VERBOSITY, F_ID, LOG_ID; pbool LOG>
 defproc logger_file (chan?(int<D_WIDTH>) I[IN_CHANNELS]; chan!(int<D_WIDTH>) O[IN_CHANNELS])
 {
     int<D_WIDTH> buf[IN_CHANNELS];

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -173,7 +173,7 @@ function buffer_create () : int<32>;
  * - LOG: Logger enable parameter
  *
  */
-export template<pint D_WIDTH; pbool LOG>
+export template<pint D_WIDTH, BUFFER_ID; pbool LOG>
 defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable_in, enable_out)
 {
     // the bit width must be smaller than 64 bit (limitation of C function import)
@@ -203,7 +203,7 @@ defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable
             assert (success, "Write to buffer failed!");
 
             [ LOG ->
-                log ("Written ", write_buf, "%x (0x", write_buf, ") to buffer")
+                log ("Buffer ", BUFFER_ID, ": Written ", write_buf, "%x (0x", write_buf, ") to buffer")
             [] else ->
                 skip
             ];
@@ -226,7 +226,7 @@ defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable
             O!read_buf;
 
             [ LOG ->
-                log ("Read ", read_buf, "%x (0x", read_buf, ") from buffer")
+                log ("Buffer ", BUFFER_ID, ": Read ", read_buf, "%x (0x", read_buf, ") from buffer")
             [] else ->
                 skip
             ];

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -174,7 +174,7 @@ function buffer_create () : int<32>;
  *
  */
 export template<pint D_WIDTH, BUFFER_ID; pbool LOG>
-defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable_in, enable_out)
+defproc buffer_en (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable_in, enable_out)
 {
     // the bit width must be smaller than 64 bit (limitation of C function import)
     {D_WIDTH < 64};
@@ -235,6 +235,13 @@ defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable
             empty := buffer_empty (id)
         ]
     }
+}
+
+/** buffer_en, with both enable_in and enable_out set to 1 */
+export defproc buffer <: buffer_en ()
+{
+    l_sethi lx(enable_in);
+    l_sethi lx(enable_out);
 }
 
 /*

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -304,6 +304,6 @@ defproc l_sethi (bool out)
         [keeper=2;after=0] ~x -> out+
         [keeper=2;after=0] x -> x-
     }
-}  
+}
 
 }

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -276,7 +276,7 @@ defproc splitter (chan?(int<D_WIDTH>) I; chan?(int<D_WIDTH>) O[OUT_CHANNELS])
 
             // log if needed
             [ LOG ->
-                log ("Splitter ", SPLITTER_ID, ": Received value ", buf[i], "%x (0x", buf[i], ")")
+                log ("Splitter ", SPLITTER_ID, ": Received value ", buf, "%x (0x", buf, ")")
             [] else ->
                 skip
             ]

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -21,6 +21,25 @@
 
 namespace sim {
 
+/**
+ * Cell which pulls constantly high
+ * Used to create a non-en version for sources
+ * and sinks
+ */
+defproc l_sethi (bool out)
+{
+    bool x;
+    
+    spec {
+        rand_init (x)
+    }
+    
+    prs {
+        [keeper=2;after=0] ~x -> out+
+        [keeper=2;after=0] x -> x-
+    }
+}
+
 /*
  * Simple multi-channel logger
  *
@@ -240,8 +259,8 @@ defproc buffer_en (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, ena
 /** buffer_en, with both enable_in and enable_out set to 1 */
 export defproc buffer <: buffer_en ()
 {
-    l_sethi lx(enable_in);
-    l_sethi lx(enable_out);
+    l_sethi in_en_hi(enable_in);
+    l_sethi out_en_hi(enable_out);
 }
 
 /*
@@ -292,25 +311,5 @@ defproc splitter (chan?(int<D_WIDTH>) I; chan?(int<D_WIDTH>) O[OUT_CHANNELS])
 }
 
 // add token counter -> generate finished signal when tokens = a certain number
-
-
-/**
- * Cell which pulls constantly high
- * Used to create a non-en version for sources
- * and sinks
- */
-defproc l_sethi (bool out)
-{
-    bool x;
-    
-    spec {
-        rand_init (x)
-    }
-    
-    prs {
-        [keeper=2;after=0] ~x -> out+
-        [keeper=2;after=0] x -> x-
-    }
-}
 
 }

--- a/simlib/act/util.act
+++ b/simlib/act/util.act
@@ -28,7 +28,7 @@ namespace sim {
  *
  * Features:
  * - Generate log line on passing token
- * - Enable through parameter
+ * - Enable logging through parameter
  * - Zero slack behavior
  *
  * Parameters:
@@ -79,21 +79,17 @@ export function write_log (int<32> writer_id; int<8> verbosity; int<32> log_id, 
  * Use this if you need a token logger on any channel
  * which saves tokens into a file.
  *
- * Eventually, this logger will have fancy output and multi-
- * channel capability; this is currently not possible due
- * to missing support for strings in the core language.
- *
  * Features:
  * - Generate log line on passing token
  * - Save to file
- * - Enable through parameter
+ * - Enable logging through parameter
  * - Zero slack behavior
  *
  * Parameters:
  * - D_WIDTH: Data output bus width
  * - IN_CHANNELS: Number of channels
  * - F_ID: ID of the file to save into
- * - LOG_ID: ID of the logger (currently unused)
+ * - LOG_ID: ID of the logger (used in log output)
  * - VERBOSITY: Verbosity with which to print to the file; 0: not verbose, 2: very verbose
  * - LOG: Logger enable parameter
  *
@@ -160,7 +156,7 @@ function buffer_create () : int<32>;
  * while the source can produce tokens with whatever speed the DUT
  * can consume them.
  *
- * Do not write to the empty flag.
+ * Leave the empty flag unconnected.
  *
  * Features:
  * - Infinite capacity (theoretically)
@@ -241,24 +237,73 @@ defproc buffer (chan?(int<D_WIDTH>) I; chan!(int<D_WIDTH>) O; bool empty, enable
     }
 }
 
+/*
+ * Token splitter
+ *
+ * Use this if you need to copy a token to multiple output channels.
+ *
+ * Features:
+ * - Generate log line on passing token
+ * - Enable logging through parameter
+ * - Zero slack behavior
+ *
+ * Ports:
+ * - I: Splitter input
+ * - O: Splitter output
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels
+ * - SPLITTER_ID: ID of the splitter (used in log output)
+ * - LOG: Logger enable parameter
+ *
+ */
+export template<pint D_WIDTH, OUT_CHANNELS, SPLITTER_ID; pbool LOG>
+defproc splitter (chan?(int<D_WIDTH>) I; chan?(int<D_WIDTH>) O[OUT_CHANNELS])
+{
+    int<D_WIDTH> buf;
+
+    chp {
+        *[
+            // listen to input channel
+            [#I];
+
+            // forward the data to all output channels (zero-slack)
+            (, i : OUT_CHANNELS : O[i]!I);
+
+            // get the data
+            I?buf;
+
+            // log if needed
+            [ LOG ->
+                log ("Splitter ", SPLITTER_ID, ": Received value ", buf[i], "%x (0x", buf[i], ")")
+            [] else ->
+                skip
+            ]
+        ]
+    }
+}
 
 // add token counter -> generate finished signal when tokens = a certain number
 
 
-/*
- * set the output to the constant 1
+/**
+ * Cell which pulls constantly high
+ * Used to create a non-en version for sources
+ * and sinks
  */
 defproc l_sethi (bool out)
 {
-  bool x;
-  spec {
-    rand_init (x)
-  }
-  prs {
-    [keeper=2;after=0] ~x -> out+
-    [keeper=2;after=0] x -> x-
-  }
+    bool x;
+    
+    spec {
+        rand_init (x)
+    }
+    
+    prs {
+        [keeper=2;after=0] ~x -> out+
+        [keeper=2;after=0] x -> x-
+    }
 }  
-
 
 }

--- a/simlib/test/buffer_0/test.act
+++ b/simlib/test/buffer_0/test.act
@@ -13,7 +13,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, true> buf;
+    sim::buffer<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_0/test.act
+++ b/simlib/test/buffer_0/test.act
@@ -13,7 +13,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, 0, true> buf;
+    sim::buffer_en<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_0/test.truth
+++ b/simlib/test/buffer_0/test.truth
@@ -1,8 +1,8 @@
-<buf>  Written 4 (0x4) to buffer
-<buf>  Written 7 (0x7) to buffer
-<buf>  Written 1 (0x1) to buffer
-<buf>  Written 9 (0x9) to buffer
-<buf>  Read 4 (0x4) from buffer
-<buf>  Read 7 (0x7) from buffer
-<buf>  Read 1 (0x1) from buffer
-<buf>  Read 9 (0x9) from buffer
+<buf>  Buffer 0: Written 4 (0x4) to buffer
+<buf>  Buffer 0: Written 7 (0x7) to buffer
+<buf>  Buffer 0: Written 1 (0x1) to buffer
+<buf>  Buffer 0: Written 9 (0x9) to buffer
+<buf>  Buffer 0: Read 4 (0x4) from buffer
+<buf>  Buffer 0: Read 7 (0x7) from buffer
+<buf>  Buffer 0: Read 1 (0x1) from buffer
+<buf>  Buffer 0: Read 9 (0x9) from buffer

--- a/simlib/test/buffer_1/test.act
+++ b/simlib/test/buffer_1/test.act
@@ -13,7 +13,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, true> buf;
+    sim::buffer<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_1/test.act
+++ b/simlib/test/buffer_1/test.act
@@ -13,7 +13,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, 0, true> buf;
+    sim::buffer_en<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_1/test.truth
+++ b/simlib/test/buffer_1/test.truth
@@ -1,8 +1,8 @@
-<buf>  Written 4 (0x4) to buffer
-<buf>  Written 7 (0x7) to buffer
-<buf>  Read 4 (0x4) from buffer
-<buf>  Read 7 (0x7) from buffer
-<buf>  Written 1 (0x1) to buffer
-<buf>  Read 1 (0x1) from buffer
-<buf>  Written 9 (0x9) to buffer
-<buf>  Read 9 (0x9) from buffer
+<buf>  Buffer 0: Written 4 (0x4) to buffer
+<buf>  Buffer 0: Written 7 (0x7) to buffer
+<buf>  Buffer 0: Read 4 (0x4) from buffer
+<buf>  Buffer 0: Read 7 (0x7) from buffer
+<buf>  Buffer 0: Written 1 (0x1) to buffer
+<buf>  Buffer 0: Read 1 (0x1) from buffer
+<buf>  Buffer 0: Written 9 (0x9) to buffer
+<buf>  Buffer 0: Read 9 (0x9) from buffer

--- a/simlib/test/buffer_2/test.act
+++ b/simlib/test/buffer_2/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, true> buf;
+    sim::buffer<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = GND;

--- a/simlib/test/buffer_2/test.act
+++ b/simlib/test/buffer_2/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, 0, true> buf;
+    sim::buffer_en<D_WIDTH, 0, true> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = GND;

--- a/simlib/test/buffer_2/test.truth
+++ b/simlib/test/buffer_2/test.truth
@@ -1,2 +1,2 @@
 <>  Sent the data, trying to pop
-<buf>  Written 4 (0x4) to buffer
+<buf>  Buffer 0: Written 4 (0x4) to buffer

--- a/simlib/test/buffer_3/test.act
+++ b/simlib/test/buffer_3/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, 0, true> buf;
+    sim::buffer_en<D_WIDTH, 0, true> buf;
 
     buf.enable_in = GND;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_3/test.act
+++ b/simlib/test/buffer_3/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, true> buf;
+    sim::buffer<D_WIDTH, 0, true> buf;
 
     buf.enable_in = GND;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_4/test.act
+++ b/simlib/test/buffer_4/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, 0, false> buf;
+    sim::buffer_en<D_WIDTH, 0, false> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/buffer_4/test.act
+++ b/simlib/test/buffer_4/test.act
@@ -14,7 +14,7 @@ defproc test ()
 
     int res;
 
-    sim::buffer<D_WIDTH, false> buf;
+    sim::buffer<D_WIDTH, 0, false> buf;
 
     buf.enable_in = Vdd;
     buf.enable_out = Vdd;

--- a/simlib/test/logger_file_3/test.act
+++ b/simlib/test/logger_file_3/test.act
@@ -13,7 +13,7 @@ defproc test ()
     pint D_WIDTH = 8;
     int out;
 
-    sim::logger_file<D_WIDTH, 2, 0, 0, 1, true> log;
+    sim::logger_file<D_WIDTH, 2, 1, 0, 0, true> log;
     sim::sink_en<D_WIDTH, 0, true> snk_0;
     sim::sink_en<D_WIDTH, 1, true> snk_1;
 

--- a/simlib/test/logger_file_4/test.act
+++ b/simlib/test/logger_file_4/test.act
@@ -13,7 +13,7 @@ defproc test ()
     pint D_WIDTH = 8;
     int out;
 
-    sim::logger_file<D_WIDTH, 2, 0, 0, 2, true> log;
+    sim::logger_file<D_WIDTH, 2, 2, 0, 0, true> log;
     sim::sink_en<D_WIDTH, 0, true> snk_0;
     sim::sink_en<D_WIDTH, 1, true> snk_1;
 


### PR DESCRIPTION
Random sources now have the same versions as normal sources, I added a generic scoreboard in case someone needs more intricate checks so they can use the standard logging format, and a token splitter (I wanted that to be in the last version but didn't have the time).
And the parameters are now in the correct order.
Readme is updated