### PR TITLE
Fail when trying to fit a value into too narrow variable

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -779,7 +779,12 @@ int process_set (int argc, char **argv)
       return LISP_RET_ERROR;
     }
 
+    BigInt before = rd;
     rd.setWidth (otmp->getWidth());
+    if (before != rd) {
+      fprintf(stderr, "Value does not fit into variable's bitwidth.\n");
+      return LISP_RET_ERROR;
+    }
 
     const ActSim::watchpt_bucket *nm;
     if ((nm = glob_sim->chkWatchPt (1, offset))) {


### PR DESCRIPTION
Currently trying to fit a 64bit value into a 32bit variable via `set` works by (silently) dropping the 32 msbs.

This checks that the passed value fits into the variable and otherwise throws an error.