### PR TITLE
Disable DC analysis

### DIFF
--- a/xycesim.cc
+++ b/xycesim.cc
@@ -799,7 +799,7 @@ void XyceActInterface::initXyce ()
 
 
   A_FREE (xyce_glob);
-  fprintf (sfp, ".tran 0 1\n");
+  fprintf (sfp, ".tran 0 1 NOOP\n");
 
   // parse output format string: colon-separated list of formats
   // it can include ONE Xyce-internal format and any number of


### PR DESCRIPTION
DC analysis for bigger circuits is often failing. Therefore actsim is failing its simulation with ```WARNING: Xyce: simulateUntil failed. Stopping Xyce.```. As we are always running a reset sequence, an initial condition with all zeros should be good, as the start state is set by reset.